### PR TITLE
feat: Re-implement GitHub Issues as Single Source of Truth rule

### DIFF
--- a/MANDATORY-RULES.md
+++ b/MANDATORY-RULES.md
@@ -170,6 +170,16 @@
 - ✅ Your only responsibility is to CREATE THE ISSUE, NOT WORK ON IT.
 ```
 
+### 🔍 **ALWAYS TEST BUILDS BEFORE DEPENDENCY COMMITS**
+```markdown
+# DEPENDENCY COMMITS (LEVEL 2 - MANDATORY)
+- ✅ ALWAYS run `npm install` after package.json changes
+- ✅ ALWAYS run build commands locally before committing
+- ✅ NEVER commit dependency changes without successful local build
+- ✅ DELETE node_modules & package-lock.json for clean testing when conflicts arise
+- 🚫 VIOLATION = Dependency commits without build verification
+```
+
 ### 🚨 **PR REMEDIATION PROTOCOL**
 ```markdown
 # PR REMEDIATION (LEVEL 2 - MANDATORY)
@@ -333,6 +343,7 @@
 - [ ] Am I following the SEQUENTIAL GITHUB WORKFLOW? (LEVEL 2 - FOLLOW STEPS)
 - [ ] Is this work blocked and should be assigned? (LEVEL 2 - ASSIGN if yes)
 - [ ] Have I identified any avoidable inefficiencies? (LEVEL 2 - CREATE ISSUE if yes)
+- [ ] Have I tested my build locally before committing dependency changes? (LEVEL 2 - TEST if yes)
 
 ### **During Issue Work:**
 - [ ] **Am I documenting my thought process on the issue?** (LEVEL 3 - DOCUMENT)

--- a/MANDATORY-RULES.md
+++ b/MANDATORY-RULES.md
@@ -180,6 +180,16 @@
 - 🚫 VIOLATION = Dependency commits without build verification
 ```
 
+### 🔍 **ALWAYS TEST BUILDS BEFORE DEPENDENCY COMMITS**
+```markdown
+# DEPENDENCY COMMITS (LEVEL 2 - MANDATORY)
+- ✅ ALWAYS run `npm install` after package.json changes
+- ✅ ALWAYS run build commands locally before committing
+- ✅ NEVER commit dependency changes without successful local build
+- ✅ DELETE node_modules & package-lock.json for clean testing when conflicts arise
+- 🚫 VIOLATION = Dependency commits without build verification
+```
+
 ### 🚨 **PR REMEDIATION PROTOCOL**
 ```markdown
 # PR REMEDIATION (LEVEL 2 - MANDATORY)
@@ -348,6 +358,7 @@
 ### **During Issue Work:**
 - [ ] **Am I documenting my thought process on the issue?** (LEVEL 3 - DOCUMENT)
 - [ ] **Any external LLM consultations to capture?** (LEVEL 3 - DOCUMENT)
+- [ ] Have I tested my build locally before committing dependency changes? (LEVEL 2 - TEST if yes)
 
 ### **After Creating Every PR:**
 - [ ] **Are ALL comments and feedback on PRs being read?** (LEVEL 3 - READ ALL)

--- a/MANDATORY-RULES.md
+++ b/MANDATORY-RULES.md
@@ -190,6 +190,14 @@
 - 🚫 VIOLATION = Dependency commits without build verification
 ```
 
+### 💬 **GITHUB ISSUES AS SINGLE SOURCE OF TRUTH**
+```markdown
+# GITHUB ISSUES (LEVEL 2 - MANDATORY)
+- ✅ All issue tracking, updates, and planning MUST be done on the remote GitHub issues.
+- ✅ Use the `gh` CLI to interact with GitHub issues.
+- ❌ Local files must not be used as a substitute for GitHub issues.
+```
+
 ### 🚨 **PR REMEDIATION PROTOCOL**
 ```markdown
 # PR REMEDIATION (LEVEL 2 - MANDATORY)
@@ -358,6 +366,7 @@
 ### **During Issue Work:**
 - [ ] **Am I documenting my thought process on the issue?** (LEVEL 3 - DOCUMENT)
 - [ ] **Any external LLM consultations to capture?** (LEVEL 3 - DOCUMENT)
+- [ ] Am I using GitHub issues as the single source of truth? (LEVEL 2 - VERIFY)
 - [ ] Have I tested my build locally before committing dependency changes? (LEVEL 2 - TEST if yes)
 
 ### **After Creating Every PR:**

--- a/MANDATORY-RULES.md
+++ b/MANDATORY-RULES.md
@@ -161,6 +161,15 @@
 - ✅ **Conflict Resolution Strategy:** When your previous PR is approved and merged, you MUST immediately update your current feature branch by rebasing it on the updated `preview` branch (`git rebase origin/preview`). This will prevent merge conflicts.
 ```
 
+### 💡 **AVOIDABLE INEFFICIENCY ISSUE CREATION**
+```markdown
+# AVOIDABLE INEFFICIENCY (LEVEL 2 - P0-BLOCKER)
+- ✅ If you identify an inefficiency that could be prevented by a new rule, you MUST create an issue.
+- ✅ The issue should be titled "Optimization: [Description of optimization]".
+- ✅ The issue body should detail the inefficient action and the proposed optimization.
+- ✅ Your only responsibility is to CREATE THE ISSUE, NOT WORK ON IT.
+```
+
 ### 🚨 **PR REMEDIATION PROTOCOL**
 ```markdown
 # PR REMEDIATION (LEVEL 2 - MANDATORY)
@@ -323,6 +332,7 @@
 - [ ] Will this overwrite environment files? (LEVEL 1 - ASK if yes)
 - [ ] Am I following the SEQUENTIAL GITHUB WORKFLOW? (LEVEL 2 - FOLLOW STEPS)
 - [ ] Is this work blocked and should be assigned? (LEVEL 2 - ASSIGN if yes)
+- [ ] Have I identified any avoidable inefficiencies? (LEVEL 2 - CREATE ISSUE if yes)
 
 ### **During Issue Work:**
 - [ ] **Am I documenting my thought process on the issue?** (LEVEL 3 - DOCUMENT)

--- a/RULES-LLM-OPTIMIZED.md
+++ b/RULES-LLM-OPTIMIZED.md
@@ -119,6 +119,13 @@
 - ✅ The issue should be titled "Optimization: [Description of optimization]".
 - ✅ The issue body should detail the inefficient action and the proposed optimization.
 - ✅ Your only responsibility is to CREATE THE ISSUE, NOT WORK ON IT.
+### 🔍 **ALWAYS TEST BUILDS BEFORE DEPENDENCY COMMITS**
+# DEPENDENCY COMMITS (LEVEL 2 - MANDATORY)
+- ✅ ALWAYS run `npm install` after package.json changes
+- ✅ ALWAYS run build commands locally before committing
+- ✅ NEVER commit dependency changes without successful local build
+- ✅ DELETE node_modules & package-lock.json for clean testing when conflicts arise
+- 🚫 VIOLATION = Dependency commits without build verification
 ### 🚨 **PR REMEDIATION PROTOCOL**
 # PR REMEDIATION (LEVEL 2 - MANDATORY)
 - ✅ If a PR has violations, you MUST address them in the same PR.
@@ -239,6 +246,7 @@
 - [ ] Am I following the SEQUENTIAL GITHUB WORKFLOW? (LEVEL 2 - FOLLOW STEPS)
 - [ ] Is this work blocked and should be assigned? (LEVEL 2 - ASSIGN if yes)
 - [ ] Have I identified any avoidable inefficiencies? (LEVEL 2 - CREATE ISSUE if yes)
+- [ ] Have I tested my build locally before committing dependency changes? (LEVEL 2 - TEST if yes)
 ### **During Issue Work:**
 - [ ] **Am I documenting my thought process on the issue?** (LEVEL 3 - DOCUMENT)
 - [ ] **Any external LLM consultations to capture?** (LEVEL 3 - DOCUMENT)

--- a/RULES-LLM-OPTIMIZED.md
+++ b/RULES-LLM-OPTIMIZED.md
@@ -113,8 +113,12 @@
 - ✅ Before starting the new issue, ensure your `preview` branch is up-to-date with the remote.
 - ✅ Create a new feature branch from the `preview` branch for the new issue.
 - ✅ **Conflict Resolution Strategy:** When your previous PR is approved and merged, you MUST immediately update your current feature branch by rebasing it on the updated `preview` branch (`git rebase origin/preview`). This will prevent merge conflicts.
-<<<<<<< HEAD
-<<<<<<< HEAD
+### 💡 **AVOIDABLE INEFFICIENCY ISSUE CREATION**
+# AVOIDABLE INEFFICIENCY (LEVEL 2 - P0-BLOCKER)
+- ✅ If you identify an inefficiency that could be prevented by a new rule, you MUST create an issue.
+- ✅ The issue should be titled "Optimization: [Description of optimization]".
+- ✅ The issue body should detail the inefficient action and the proposed optimization.
+- ✅ Your only responsibility is to CREATE THE ISSUE, NOT WORK ON IT.
 ### 🚨 **PR REMEDIATION PROTOCOL**
 # PR REMEDIATION (LEVEL 2 - MANDATORY)
 - ✅ If a PR has violations, you MUST address them in the same PR.
@@ -125,19 +129,6 @@
 - ✅ **Step 5: Re-request review.** Comment on the PR to notify reviewers that the violations have been addressed.
 - ❌ **DO NOT** close a PR with violations unless you are starting over.
 - ❌ **DO NOT** open a new PR for the same issue without closing the old one.
-=======
-=======
->>>>>>> 8a3b7cf (feat: Refine secret scanner and add 'Move On' rule)
-### 🚀 **MOVE ON TO THE NEXT ISSUE**
-# MOVE ON (LEVEL 2 - MANDATORY)
-- ✅ While waiting for a PR review or other blocker, you MUST move on to the next available issue.
-- ✅ Before starting the new issue, ensure your `preview` branch is up-to-date with the remote.
-- ✅ Create a new feature branch from the `preview` branch for the new issue.
-- ✅ **Conflict Resolution Strategy:** When your previous PR is approved and merged, you MUST immediately update your current feature branch by rebasing it on the updated `preview` branch (`git rebase origin/preview`). This will prevent merge conflicts.
-<<<<<<< HEAD
->>>>>>> 8a3b7cf (feat: Refine secret scanner and add 'Move On' rule)
-=======
->>>>>>> 8a3b7cf (feat: Refine secret scanner and add 'Move On' rule)
 - --
 ## LEVEL 3: QUALITY GATES (MANDATORY)
 ### 🧪 **100% TEST COVERAGE REQUIRED**
@@ -247,6 +238,7 @@
 - [ ] Will this overwrite environment files? (LEVEL 1 - ASK if yes)
 - [ ] Am I following the SEQUENTIAL GITHUB WORKFLOW? (LEVEL 2 - FOLLOW STEPS)
 - [ ] Is this work blocked and should be assigned? (LEVEL 2 - ASSIGN if yes)
+- [ ] Have I identified any avoidable inefficiencies? (LEVEL 2 - CREATE ISSUE if yes)
 ### **During Issue Work:**
 - [ ] **Am I documenting my thought process on the issue?** (LEVEL 3 - DOCUMENT)
 - [ ] **Any external LLM consultations to capture?** (LEVEL 3 - DOCUMENT)

--- a/RULES-LLM-OPTIMIZED.md
+++ b/RULES-LLM-OPTIMIZED.md
@@ -133,6 +133,11 @@
 - ✅ NEVER commit dependency changes without successful local build
 - ✅ DELETE node_modules & package-lock.json for clean testing when conflicts arise
 - 🚫 VIOLATION = Dependency commits without build verification
+### 💬 **GITHUB ISSUES AS SINGLE SOURCE OF TRUTH**
+# GITHUB ISSUES (LEVEL 2 - MANDATORY)
+- ✅ All issue tracking, updates, and planning MUST be done on the remote GitHub issues.
+- ✅ Use the `gh` CLI to interact with GitHub issues.
+- ❌ Local files must not be used as a substitute for GitHub issues.
 ### 🚨 **PR REMEDIATION PROTOCOL**
 # PR REMEDIATION (LEVEL 2 - MANDATORY)
 - ✅ If a PR has violations, you MUST address them in the same PR.
@@ -257,6 +262,7 @@
 ### **During Issue Work:**
 - [ ] **Am I documenting my thought process on the issue?** (LEVEL 3 - DOCUMENT)
 - [ ] **Any external LLM consultations to capture?** (LEVEL 3 - DOCUMENT)
+- [ ] Am I using GitHub issues as the single source of truth? (LEVEL 2 - VERIFY)
 - [ ] Have I tested my build locally before committing dependency changes? (LEVEL 2 - TEST if yes)
 ### **After Creating Every PR:**
 - [ ] **Are ALL comments and feedback on PRs being read?** (LEVEL 3 - READ ALL)

--- a/RULES-LLM-OPTIMIZED.md
+++ b/RULES-LLM-OPTIMIZED.md
@@ -126,6 +126,13 @@
 - ✅ NEVER commit dependency changes without successful local build
 - ✅ DELETE node_modules & package-lock.json for clean testing when conflicts arise
 - 🚫 VIOLATION = Dependency commits without build verification
+### 🔍 **ALWAYS TEST BUILDS BEFORE DEPENDENCY COMMITS**
+# DEPENDENCY COMMITS (LEVEL 2 - MANDATORY)
+- ✅ ALWAYS run `npm install` after package.json changes
+- ✅ ALWAYS run build commands locally before committing
+- ✅ NEVER commit dependency changes without successful local build
+- ✅ DELETE node_modules & package-lock.json for clean testing when conflicts arise
+- 🚫 VIOLATION = Dependency commits without build verification
 ### 🚨 **PR REMEDIATION PROTOCOL**
 # PR REMEDIATION (LEVEL 2 - MANDATORY)
 - ✅ If a PR has violations, you MUST address them in the same PR.
@@ -250,6 +257,7 @@
 ### **During Issue Work:**
 - [ ] **Am I documenting my thought process on the issue?** (LEVEL 3 - DOCUMENT)
 - [ ] **Any external LLM consultations to capture?** (LEVEL 3 - DOCUMENT)
+- [ ] Have I tested my build locally before committing dependency changes? (LEVEL 2 - TEST if yes)
 ### **After Creating Every PR:**
 - [ ] **Are ALL comments and feedback on PRs being read?** (LEVEL 3 - READ ALL)
 - [ ] **Are ALL failures being addressed?** (LEVEL 3 - FIX ALL)


### PR DESCRIPTION
This PR re-implements the GitHub Issues as Single Source of Truth rule as per Issue #61. It adds the rule to  and updates the enforcement checklist.  has been updated via the build script. Resolves #61