### PR TITLE
feat: Enforce GitHub Issues as single source of truth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json

--- a/MANDATORY-RULES.md
+++ b/MANDATORY-RULES.md
@@ -35,6 +35,16 @@
 - 🚨 VIOLATION = Work without a tracked issue.
 ```
 
+### 📢 **GITHUB ISSUES AS SINGLE SOURCE OF TRUTH**
+```markdown
+# ISSUE MANAGEMENT (LEVEL 2 - MANDATORY)
+- ✅ GITHUB ISSUES are the single source of truth for all work.
+- ❌ DO NOT use local markdown files, notes, or any other method for issue tracking.
+- ✅ ALL updates, planning, and discussions must happen on the remote GitHub issue.
+- ✅ Use the `gh` CLI to interact with issues whenever possible.
+- 🚨 VIOLATION = Fragmented information, loss of context, and workflow violations.
+```
+
 ### SEQ-2: CREATE A BRANCH
 ```markdown
 # STEP 2: BRANCH (MANDATORY)


### PR DESCRIPTION
This PR introduces a new Level 2 mandatory rule to enforce the use of GitHub Issues as the single source of truth for all work, as detailed in issue #56. This will prevent fragmented information, loss of context, and workflow violations. Closes #56