### PR TITLE
fix: Add statuses: write permission to rule-checker workflow

### DIFF
--- a/.github/workflows/rule-checker.yml
+++ b/.github/workflows/rule-checker.yml
@@ -14,6 +14,7 @@ jobs:
       pull-requests: write
       checks: write
       issues: read
+      statuses: write
       
     steps:
       - name: Checkout PR code


### PR DESCRIPTION
This PR fixes a bug in the rule-compliance check workflow that was causing a 'Resource not accessible by integration' error. The error was caused by the workflow not having the required  permission to post a status check to the pull request. This commit adds the necessary permission to the  file. Closes #71